### PR TITLE
Macro-ify

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -55,14 +55,14 @@
                                 (syntax->list #'[par ...]))
 
      #'(begin
-         (: fit-params : (-> Flonums Flonums (List par-type ...)))
+         (: fit-params : (-> Flonums Flonums (Values par-type ...)))
          (define (fit-params pts-x pts-y)
            calc-form ...
-           (list par ...))
+           (values par ...))
 
          (: fitter : (-> Flonums Flonums Fit-Function))
          (define (fitter pts-x pts-y)
-           (match-define (list par ...) (fit-params pts-x pts-y))
+           (define-values [par ...] (fit-params pts-x pts-y))
            (λ ([x : Real]) output-expr))
 
          (: grapher : Grapher)
@@ -100,15 +100,15 @@
   (define Σxy (Σ (map * pts-x pts-y)))
   (define ΣxΣy (* Σx Σy))
   (define Σx^2 (Σ (map sqr pts-x)))
-  (define slope
+  (define b
     (/ (- (* len Σxy) ΣxΣy)
        (- (* len Σx^2) (sqr Σx))))
-  (define offset
-    (/ (- Σy (* slope Σx))
+  (define a
+    (/ (- Σy (* b Σx))
        len))
 
-  #:params [slope offset]
-  #:function (+ (* slope (fl x)) offset))
+  #:params [a b]
+  #:function (+ a (* b (fl x))))
 
 
 ;; --------------------

--- a/main.rkt
+++ b/main.rkt
@@ -4,34 +4,24 @@
          graph/log
          graph/power
 
-         linear-fit
-         exp-fit
-         log-fit
-         power-fit)
+         linear-fit-params linear-fit
+         exp-fit-params exp-fit
+         log-fit-params log-fit
+         power-fit-params power-fit)
 
 (require plot/no-gui math/flonum)
 
 ;; math from http://mathworld.wolfram.com/LeastSquaresFitting.html
 
+(define-type Flonums (Listof Nonnegative-Flonum))
+
 (define-type Grapher
-  (->* ((Listof Nonnegative-Flonum) (Listof Nonnegative-Flonum))
+  (->* (Flonums Flonums)
        ((Option (Listof Flonum)))
        (Values renderer2d renderer2d renderer2d)))
-(define-type Fitter (-> (Listof Nonnegative-Flonum) (Listof Nonnegative-Flonum)
-                        (-> Real Real)))
 
-(: graph/linear : Grapher)
-(define (graph/linear pts-x pts-y [error #f])
-  (graph/gen pts-x pts-y error linear-fit))
-(: graph/exponential : Grapher)
-(define (graph/exponential pts-x pts-y [error #f])
-  (graph/gen pts-x pts-y error exp-fit))
-(: graph/log : Grapher)
-(define (graph/log pts-x pts-y [error #f])
-  (graph/gen pts-x pts-y error log-fit))
-(: graph/power : Grapher)
-(define (graph/power pts-x pts-y [error #f])
-  (graph/gen pts-x pts-y error power-fit))
+(define-type Fitter (-> Flonums Flonums (-> Real Real)))
+
 
 (: graph/gen : (-> (Listof Nonnegative-Flonum) (Listof Nonnegative-Flonum)
                    (Option (Listof Flonum))
@@ -49,8 +39,12 @@
 (: Σ : (-> (Listof Flonum) Flonum))
 (define (Σ l) (foldl + 0.0 l))
 
-(: linear-fit : Fitter)
-(define (linear-fit pts-x pts-y)
+
+;; --------------------
+;; | linear fit
+
+(: linear-fit-params : (-> Flonums Flonums (List Real Real)))
+(define (linear-fit-params pts-x pts-y)
   (define len (length pts-x))
   (define Σx (Σ pts-x))
   (define Σy (Σ pts-y))
@@ -63,34 +57,56 @@
   (define offset
     (/ (- Σy (* slope Σx))
        len))
+  (list slope offset))
+
+(: linear-fit : Fitter)
+(define (linear-fit pts-x pts-y)
+  (match-define (list slope offset)
+    (linear-fit-params pts-x pts-y))
   (lambda ([x : Real]) (+ (* slope (fl x)) offset)))
 
+(: graph/linear : Grapher)
+(define (graph/linear pts-x pts-y [error #f])
+  (graph/gen pts-x pts-y error linear-fit))
+
+
+;; --------------------
+;; | exp fit
+
 ;; see http://mathworld.wolfram.com/LeastSquaresFittingExponential.html
-(: exp-fit : Fitter)
-(define (exp-fit pts-x pts-y)
-
+(: exp-fit-params : (-> Flonums Flonums (List Real Real)))
+(define (exp-fit-params pts-x pts-y)
   (define lny (map log pts-y))
-
   (define x^2 (map sqr pts-x))
   (define Σx^2y  (Σ (map * x^2 pts-y)))
   (define Σylny  (Σ (map * pts-y lny)))
   (define Σxy    (Σ (map * pts-x pts-y)))
   (define Σxylny (Σ (map * pts-x pts-y lny)))
   (define Σy     (Σ pts-y))
-
   (define ΣyΣx^2y-Σxy^2 (- (* Σy Σx^2y) (sqr Σxy)))
   (define a (/ (- (* Σx^2y Σylny) (* Σxy Σxylny))
                ΣyΣx^2y-Σxy^2))
   (define b (/ (- (* Σy Σxylny) (* Σxy Σylny))
                ΣyΣx^2y-Σxy^2))
-  (define A (exp a))
-  (lambda ([x : Real]) (* A (exp (* b (fl x))))))
+  (list (exp a) b))
 
-(define-predicate nnn? Nonnegative-Flonum)
+(: exp-fit : Fitter)
+(define (exp-fit pts-x pts-y)
+  (match-define (list A B)
+    (exp-fit-params pts-x pts-y))
+  (lambda ([x : Real]) (* A (exp (* B (fl x))))))
+
+(: graph/exponential : Grapher)
+(define (graph/exponential pts-x pts-y [error #f])
+  (graph/gen pts-x pts-y error exp-fit))
+
+
+;; --------------------
+;; | log fit
+
 ;; see http://mathworld.wolfram.com/LeastSquaresFittingLogarithmic.html
-(: log-fit : Fitter)
-(define (log-fit pts-x pts-y)
-
+(: log-fit-params : (-> Flonums Flonums (List Real Real)))
+(define (log-fit-params pts-x pts-y)
   (: r* : (-> Flonum Flonum * Flonum))
   (define r* *)
   (define n (length pts-x))
@@ -107,17 +123,30 @@
   (define a
     (/ (- Σy (* b Σlnx))
        n))
+  (list a b))
+
+(: log-fit : Fitter)
+(define-predicate nnn? Nonnegative-Flonum)
+(define (log-fit pts-x pts-y)
+  (match-define (list a b)
+    (log-fit-params pts-x pts-y))
   (lambda ([x : Real])
     (define fx (fl x))
     (if (nnn? fx)
         (+ a (* b (log fx)))
         +nan.0)))
 
-(define-predicate pn? Positive-Flonum)
-;; see http://mathworld.wolfram.com/LeastSquaresFittingPowerLaw.html
-(: power-fit : Fitter)
-(define (power-fit pts-x pts-y)
+(: graph/log : Grapher)
+(define (graph/log pts-x pts-y [error #f])
+  (graph/gen pts-x pts-y error log-fit))
 
+
+;; --------------------
+;; | power fit
+
+;; see http://mathworld.wolfram.com/LeastSquaresFittingPowerLaw.html
+(: power-fit-params : (-> Flonums Flonums (List Real Real)))
+(define (power-fit-params pts-x pts-y)
   (define lnx (map log pts-x))
   (define lny (map log pts-y))
   (define n (length pts-x))
@@ -125,14 +154,22 @@
   (define Σlny (Σ lny))
   (define Σlnxlny (Σ (map * lnx lny)))
   (define Σlnx^2 (Σ (map sqr lnx)))
-
   (define b (/ (- (* n Σlnxlny) (* Σlnx Σlny))
                (- (* n Σlnx^2) (sqr Σlnx))))
-
   (define a (/ (- Σlny (* b Σlnx)) n))
+  (list a b))
 
+(: power-fit : Fitter)
+(define-predicate pn? Positive-Flonum)
+(define (power-fit pts-x pts-y)
+  (match-define (list a b)
+    (power-fit-params pts-x pts-y))
   (lambda ([x : Real])
     (define fx (fl x))
     (if (pn? fx)
         (* (exp a) (expt fx b))
         +nan.0)))
+
+(: graph/power : Grapher)
+(define (graph/power pts-x pts-y [error #f])
+  (graph/gen pts-x pts-y error power-fit))

--- a/scribblings/bestfit.scrbl
+++ b/scribblings/bestfit.scrbl
@@ -87,5 +87,52 @@ generate a best fit function of the given type.
        (line 10.0)
        (line 12.0)]
 
+@defproc[(linear-fit-params [xs (Listof Nonnegative-Flonum)]
+                            [ys (Listof Nonnegative-Flonum)])
+          (Values Real Real)]{
+
+Returns values @racket[_a] and @racket[_b] used to generate a best fit
+function of the form @tt{y = a + b x}.
+
+@inter[(linear-fit-params '(1.0 2.0 3.0) '(2.0 4.0 6.0))]
+
+}
+
+
+@defproc[(exp-fit-params [xs (Listof Nonnegative-Flonum)]
+                         [ys (Listof Nonnegative-Flonum)])
+         (Values Real Real)]{
+
+Returns values @racket[_A] and @racket[_B] used to generate a best fit
+function of the form @tt{y = A e^(B x)}.
+
+@inter[(exp-fit-params '(1.0 2.0 3.0) '(2.0 4.0 8.0))]
+
+}
+
+
+@defproc[(log-fit-params [xs (Listof Nonnegative-Flonum)]
+                         [ys (Listof Nonnegative-Flonum)])
+         (Values Real Real)]{
+
+Returns values @racket[_a] and @racket[_b] used to generate a best fit
+function of the form @tt{y = a + b ln(x)}.
+
+@inter[(log-fit-params '(2.0 4.0 8.0) '(1.0 2.0 3.0))]
+
+}
+
+
+@defproc[(power-fit-params [xs (Listof Nonnegative-Flonum)]
+                           [ys (Listof Nonnegative-Flonum)])
+         (Values Real Real)]{
+
+Returns values @racket[_A] and @racket[_B] used to generate a best fit
+function of the form @tt{y = A x^B}.
+
+@inter[(power-fit-params '(1.0 2.0 3.0) '(2.0 8.0 18.0))]
+
+}
+
 
 }


### PR DESCRIPTION
Created a macro to define X-fit and graph/Y functions automatically. This clears up the code a bit
e.g.
```racket
(define-fit [linear-fit
             linear-fit-params
             graph/linear]

  (define len (length pts-x))
  (define Σx (Σ pts-x))
  (define Σy (Σ pts-y))
  (define Σxy (Σ (map * pts-x pts-y)))
  (define ΣxΣy (* Σx Σy))
  (define Σx^2 (Σ (map sqr pts-x)))
  (define slope
    (/ (- (* len Σxy) ΣxΣy)
       (- (* len Σx^2) (sqr Σx))))
  (define offset
    (/ (- Σy (* slope Σx))
       len))

  #:params [slope offset]
  #:function (+ (* slope (fl x)) offset))
```